### PR TITLE
Add 3D starfield backdrop

### DIFF
--- a/index.html
+++ b/index.html
@@ -211,6 +211,7 @@
         let drones = [];
         let fallingFloors = [];
         let destination;
+        let starField;
         let isSliding = false;
         let jumpCount = 0;
         let isGameActive = false;
@@ -308,6 +309,7 @@
             createPlayer();
             createPackage(); // パッケージを作成
             createWorld();
+            createStarfield();
             createObstacles();
             createItems();
             createDrones();
@@ -465,6 +467,41 @@
             for (let i = 0; i < 50; i++) {
                 createBuilding();
             }
+        }
+
+        function createStarfield() {
+            const starGeometry = new THREE.BufferGeometry();
+            const starCount = 2000;
+            const positions = new Float32Array(starCount * 3);
+
+            for (let i = 0; i < starCount; i++) {
+                const direction = new THREE.Vector3(
+                    Math.random() * 2 - 1,
+                    Math.random() * 2 - 1,
+                    Math.random() * 2 - 1
+                ).normalize();
+
+                const radius = THREE.MathUtils.randFloat(200, 500);
+                direction.multiplyScalar(radius);
+
+                positions[i * 3] = direction.x;
+                positions[i * 3 + 1] = direction.y;
+                positions[i * 3 + 2] = direction.z;
+            }
+
+            starGeometry.setAttribute('position', new THREE.BufferAttribute(positions, 3));
+
+            const starMaterial = new THREE.PointsMaterial({
+                color: 0xffffff,
+                size: 1.5,
+                sizeAttenuation: true,
+                transparent: true,
+                opacity: 0.85
+            });
+
+            starField = new THREE.Points(starGeometry, starMaterial);
+            starField.name = 'starField';
+            scene.add(starField);
         }
 
         function createBuilding() {
@@ -837,6 +874,10 @@
         }
 
         function renderScene() {
+            if (starField) {
+                starField.rotation.y += 0.0005;
+                starField.rotation.x += 0.0002;
+            }
             renderer.render(scene, camera);
         }
 


### PR DESCRIPTION
## Summary
- add a starfield generator so the outer black area becomes a 3D night sky
- slowly rotate the star layer to keep the sky feeling alive

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68c89d35890483309237735f93df7025